### PR TITLE
Downgrade dotenv dependency

### DIFF
--- a/PostCards/Collection/package-lock.json
+++ b/PostCards/Collection/package-lock.json
@@ -11,7 +11,7 @@
         "compression": "^1.8.1",
         "cookie-parser": "~1.4.4",
         "debug": "~2.6.9",
-        "dotenv": "^17.2.1",
+        "dotenv": "^16.4.5",
         "ejs": "~2.6.1",
         "express": "~4.16.1",
         "helmet": "^8.1.0",
@@ -367,9 +367,9 @@
       "license": "MIT"
     },
     "node_modules/dotenv": {
-      "version": "17.2.1",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.2.1.tgz",
-      "integrity": "sha512-kQhDYKZecqnM0fCnzI5eIv5L4cAe/iRI+HqMbO/hbRdTAeXDG+M9FjipUxNfbARuEg4iHIbhnhs78BCHNbSxEQ==",
+      "version": "16.4.5",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.5.tgz",
+      "integrity": "sha512-ZmdrWBqAbIYW/W2PASi6DPd7OJbRRqtD9h5pz50jdK5Zk90un0nLBKBPXn1HULICwhf66A1VpzwuWdlxeqD5lA==",
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=12"

--- a/PostCards/Collection/package.json
+++ b/PostCards/Collection/package.json
@@ -9,7 +9,7 @@
     "compression": "^1.8.1",
     "cookie-parser": "~1.4.4",
     "debug": "~2.6.9",
-    "dotenv": "^17.2.1",
+    "dotenv": "^16.4.5",
     "ejs": "~2.6.1",
     "express": "~4.16.1",
     "helmet": "^8.1.0",


### PR DESCRIPTION
## Summary
- update the application to depend on dotenv ^16.4.5 so that it uses an available release
- refresh the lockfile entry for dotenv to match the downgraded version

## Testing
- npm install *(fails: registry access returns 403 Forbidden in this environment)*
