### PR TITLE
Fix delete postcard ID validation order

### DIFF
--- a/PostCards/Collection/controllers/postcards.js
+++ b/PostCards/Collection/controllers/postcards.js
@@ -86,13 +86,14 @@ async function postAddPostCard(body) {
 }
 
 async function deletePostCardById(id) {
+    const targetId = String(id);
+
     if (!ObjectId.isValid(targetId)) {
         const err = new Error('ID inválido.');
         err.status = 400;
         err.publicMessage = 'ID inválido.';
         throw err;
     }
-    const targetId = String(id);
     const { collection, client } = await connectToDatabase();
 
     try {


### PR DESCRIPTION
## Summary
- convert the deletion id to a string before validating it
- continue to validate the id and delete the postcard as before

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dda4ec8e2883208e5963ea600f8422